### PR TITLE
Fix Raycast scripts to use virtual environment Python

### DIFF
--- a/copy-latest-fireflies-transcript.sh
+++ b/copy-latest-fireflies-transcript.sh
@@ -15,5 +15,6 @@
 # @raycast.authorURL https://raycast.com/christian_ulstrup
 
 # Setup the environment and run the script
-source "$(dirname "$0")/.venv/bin/activate"
-python3 "$(dirname "$0")/fireflies_clipboard.py"
+cd "$(dirname "$0")"
+source .venv/bin/activate
+python "$(dirname "$0")/fireflies_clipboard.py"

--- a/fetch-fireflies-from-chrome-tabs.sh
+++ b/fetch-fireflies-from-chrome-tabs.sh
@@ -16,10 +16,11 @@
 
 # Setup the environment and run the script
 echo "Starting Fireflies transcript fetch..."
-source "$(dirname "$0")/.venv/bin/activate"
+cd "$(dirname "$0")"
+source .venv/bin/activate
 
 # Run with debug mode to provide more visibility
-python3 "$(dirname "$0")/fetch_fireflies_from_chrome_tabs.py" --paste --debug
+python "$(dirname "$0")/fetch_fireflies_from_chrome_tabs.py" --paste --debug
 
 # Show notification when complete
 echo "Fireflies transcript fetch completed!"


### PR DESCRIPTION
## Summary
- Fixed Raycast shell scripts that were failing to copy transcripts to clipboard
- Scripts now properly use the virtual environment's Python interpreter

## Problem
The Raycast scripts were calling `python3` directly, which used the system Python installation. This caused `ModuleNotFoundError` for the `pyperclip` module since it's only installed in the virtual environment.

## Solution
- Added `cd "$(dirname "$0")"` to change to the script directory first
- Changed `python3` to `python` after activating the virtual environment
- This ensures the scripts use the correct Python interpreter with all required dependencies

## Test plan
- [x] Run `fetch-fireflies-from-chrome-tabs.sh` from Raycast
- [x] Verify transcripts are copied to clipboard
- [x] Run `copy-latest-fireflies-transcript.sh` from Raycast
- [x] Verify latest transcript is copied to clipboard

🤖 Generated with [Claude Code](https://claude.ai/code)