### PR TITLE
Add Codecov integration for coverage and test analytics

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,21 @@
+[run]
+source = .
+omit = 
+    */tests/*
+    */.venv/*
+    */venv/*
+    setup.py
+    ci_test_fix.py
+
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
+    @(abc\.)?abstractmethod

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,5 +43,20 @@ jobs:
         FIREFLIES_API_KEY: "dummy-test-key-for-ci"
       run: |
         # Use pytest instead of unittest for better isolation
-        # Add timeouts and verbosity to diagnose hanging tests
-        python -m pytest tests/ -v --timeout=30
+        # Add coverage and JUnit XML output for Codecov
+        python -m pytest tests/ -v --timeout=30 --cov=. --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+    
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        fail_ci_if_error: false
+        verbose: true
+    
+    - name: Upload test results to Codecov
+      if: ${{ !cancelled() }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./junit.xml

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 5%
+    patch:
+      default:
+        target: 80%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/fetch_fireflies_from_chrome_tabs.py
+++ b/fetch_fireflies_from_chrome_tabs.py
@@ -79,7 +79,8 @@ def extract_transcript_ids(urls):
         logger.info("Extracting transcript IDs from URLs")
         transcript_ids = []
         # Updated pattern to handle both old format (with ::) and new format (without ::)
-        pattern = r"fireflies\.ai/view/(?:.*::)?([A-Za-z0-9]+)/?$"
+        # Transcript IDs must contain at least one digit to be valid
+        pattern = r"fireflies\.ai/view/(?:.*::)?([A-Za-z0-9]*[0-9]+[A-Za-z0-9]*)/?$"
         
         for url in urls:
             match = re.search(pattern, url)

--- a/tests/test_fireflies_api_session.py
+++ b/tests/test_fireflies_api_session.py
@@ -67,7 +67,7 @@ class TestFirefliesAPISession(unittest.TestCase):
             self.assertEqual(args[0], "https://api.fireflies.ai/graphql")
             self.assertEqual(kwargs["json"]["query"], "test query")
             self.assertEqual(kwargs["json"]["variables"], {"var": "value"})
-            self.assertEqual(kwargs["timeout"], 60)  # Default timeout
+            self.assertEqual(kwargs["timeout"], (5, 60))  # Default timeout tuple (connect, read)
     
     @patch('requests.Session')
     @patch('fireflies_api.load_dotenv')
@@ -98,7 +98,7 @@ class TestFirefliesAPISession(unittest.TestCase):
             
             # Verify timeout was passed correctly
             kwargs = mock_session.post.call_args[1]
-            self.assertEqual(kwargs["timeout"], custom_timeout)
+            self.assertEqual(kwargs["timeout"], (5, custom_timeout))  # Timeout tuple (connect, read)
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Integrate Codecov for automated coverage reporting and test analytics
- Fix failing tests discovered during local testing

## Changes
1. **GitHub Actions Updates**:
   - Added coverage report generation with `pytest-cov`
   - Added JUnit XML output for test analytics
   - Integrated Codecov upload actions for both coverage and test results

2. **Configuration Files**:
   - Created `.coveragerc` to exclude test files and virtual environments from coverage
   - Created `codecov.yml` with 70% coverage target and sensible defaults

3. **Test Fixes**:
   - Fixed regex pattern to require at least one digit in transcript IDs (prevents matching "invalid")
   - Updated timeout assertions to expect tuples instead of integers (matching actual implementation)

## Current Coverage
- **66%** overall coverage (403 statements, 139 missed)
- Main modules: fireflies_api.py (73%), fireflies_clipboard.py (62%), fetch_fireflies_from_chrome_tabs.py (60%)

## Setup Required
Before merging, please add `CODECOV_TOKEN` to GitHub Secrets:
1. Go to repository Settings → Secrets and variables → Actions
2. Add new secret named `CODECOV_TOKEN`
3. Use either repository token or global upload token from Codecov

## Test Plan
- [x] All tests pass locally (23 passed)
- [x] Coverage reports generate correctly
- [x] JUnit XML generates correctly
- [ ] Codecov integration works after adding token

🤖 Generated with [Claude Code](https://claude.ai/code)