### PR TITLE
Fix Codecov badge and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,12 @@ LOCAL_SCRATCHPAD.md
 debug.log
 *.log
 
+# Coverage files
+.coverage
+coverage.xml
+junit.xml
+htmlcov/
+
 # macOS
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/culstrup/fireflies-raycast.svg)](https://github.com/culstrup/fireflies-raycast/stargazers)
+[![codecov](https://codecov.io/gh/culstrup/fireflies-raycast/graph/badge.svg)](https://codecov.io/gh/culstrup/fireflies-raycast)
 [![Ko-fi](https://img.shields.io/badge/Support-Ko--fi-FF5E5B.svg)](https://ko-fi.com/culstrup)
 
 </div>


### PR DESCRIPTION
## Summary
- Fix Codecov badge by removing placeholder token
- Update .gitignore to exclude coverage files

## Changes
1. **README.md**: Removed `?token=YOUR_TOKEN` from the Codecov badge URL since it's not needed when the repository is public
2. **.gitignore**: Added coverage-related files to keep the repository clean:
   - `.coverage` - Coverage data file
   - `coverage.xml` - XML coverage report
   - `junit.xml` - JUnit test results
   - `htmlcov/` - HTML coverage report directory

## Test Plan
- [x] Badge displays correctly without token parameter
- [x] Coverage files are properly ignored

🤖 Generated with [Claude Code](https://claude.ai/code)