### PR TITLE
Fix: Add explicit workflow permissions for security

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Resolves GitHub code scanning alert about missing workflow permissions
- Adds \ to follow principle of least privilege

## Security Impact
- Explicitly restricts GITHUB_TOKEN permissions instead of inheriting potentially overprivileged organization defaults
- Follows GitHub security best practices for Actions workflows

🤖 Generated with [Claude Code](https://claude.ai/code)