### PR TITLE
feat: Add timestamps to Fireflies transcripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,13 +22,36 @@ htmlcov/
 
 # macOS
 .DS_Store
+*.DS_Store
 
 # IDE files
 .idea/
 .vscode/
 *.sublime-*
+*.swp
+*.swo
+*~
 
 # Distribution
 dist/
 build/
 *.zip
+
+# Backup files
+*-backup.*
+*.backup
+*.bak
+
+# Test artifacts
+.pytest_cache/
+.ruff_cache/
+*.pyc
+
+# Claude AI
+.claude/
+
+# Additional logs
+debug_*.log
+
+# Test data
+transcripts_for_testing/

--- a/tests/test_timestamps.py
+++ b/tests/test_timestamps.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Tests for timestamp functionality in Fireflies API"""
+
+import unittest
+
+from fireflies_api import FirefliesAPI
+
+
+class TestTimestamps(unittest.TestCase):
+    """Test timestamp functionality"""
+
+    def setUp(self):
+        """Set up test fixtures"""
+        self.api = FirefliesAPI("test_api_key")
+
+    def test_format_transcript_with_timestamps(self):
+        """Test that timestamps are correctly formatted in transcripts"""
+        # Mock transcript with timestamps
+        transcript = {
+            "title": "Test Meeting",
+            "dateString": "2025-06-05T10:00:00.000Z",
+            "summary": {"overview": "Test summary"},
+            "sentences": [
+                {"speaker_name": "Alice", "text": "Hello everyone", "start_time": 0.5, "end_time": 2.3},
+                {"speaker_name": "Bob", "text": "Hi Alice", "start_time": 3.0, "end_time": 4.5},
+                {
+                    "speaker_name": "Alice",
+                    "text": "Let's start the meeting",
+                    "start_time": 65.5,  # Over 1 minute
+                    "end_time": 68.0,
+                },
+            ],
+        }
+
+        # Format the transcript
+        formatted = self.api.format_transcript(transcript)
+
+        # Check that timestamps are included
+        self.assertIn("[00:00] Alice: Hello everyone", formatted)
+        self.assertIn("[00:03] Bob: Hi Alice", formatted)
+        self.assertIn("[01:05] Alice: Let's start the meeting", formatted)
+
+    def test_format_transcript_without_timestamps(self):
+        """Test backward compatibility when timestamps are not available"""
+        # Mock transcript without timestamps
+        transcript = {
+            "title": "Test Meeting",
+            "dateString": "2025-06-05T10:00:00.000Z",
+            "summary": {"overview": "Test summary"},
+            "sentences": [
+                {"speaker_name": "Alice", "text": "Hello everyone"},
+                {"speaker_name": "Bob", "text": "Hi Alice"},
+            ],
+        }
+
+        # Format the transcript
+        formatted = self.api.format_transcript(transcript)
+
+        # Check that it falls back to the old format without timestamps
+        self.assertIn("Alice: Hello everyone", formatted)
+        self.assertIn("Bob: Hi Alice", formatted)
+        self.assertNotIn("[", formatted)  # No timestamps
+
+    def test_format_transcript_mixed_timestamps(self):
+        """Test handling of mixed sentences with and without timestamps"""
+        # Mock transcript with some sentences having timestamps
+        transcript = {
+            "title": "Test Meeting",
+            "dateString": "2025-06-05T10:00:00.000Z",
+            "summary": None,
+            "sentences": [
+                {"speaker_name": "Alice", "text": "Hello", "start_time": 0.0},
+                {
+                    "speaker_name": "Bob",
+                    "text": "Hi",
+                    # No timestamp
+                },
+                {"speaker_name": "Charlie", "text": "Hey", "start_time": 5.5},
+            ],
+        }
+
+        # Format the transcript
+        formatted = self.api.format_transcript(transcript)
+
+        # Check mixed formatting
+        self.assertIn("[00:00] Alice: Hello", formatted)
+        self.assertIn("Bob: Hi", formatted)  # No timestamp
+        self.assertNotIn("[", formatted.split("Bob: Hi")[0].split("\n")[-1])  # Bob's line has no timestamp
+        self.assertIn("[00:05] Charlie: Hey", formatted)
+
+    def test_timestamp_formatting_edge_cases(self):
+        """Test edge cases in timestamp formatting"""
+        # Test with various timestamp values
+        transcript = {
+            "title": "Test Meeting",
+            "dateString": "2025-06-05T10:00:00.000Z",
+            "sentences": [
+                {
+                    "speaker_name": "Alice",
+                    "text": "Exactly one hour",
+                    "start_time": 3600.0,  # Exactly 1 hour
+                },
+                {
+                    "speaker_name": "Bob",
+                    "text": "Over an hour",
+                    "start_time": 3661.5,  # 1 hour, 1 minute, 1.5 seconds
+                },
+                {"speaker_name": "Charlie", "text": "Almost a minute", "start_time": 59.9},
+            ],
+        }
+
+        # Format the transcript
+        formatted = self.api.format_transcript(transcript)
+
+        # Check formatting of edge cases
+        self.assertIn("[60:00] Alice: Exactly one hour", formatted)
+        self.assertIn("[61:01] Bob: Over an hour", formatted)
+        self.assertIn("[00:59] Charlie: Almost a minute", formatted)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Added timestamps to all Fireflies transcript outputs in `[MM:SS]` format
- Timestamps show when each speaker began talking during the meeting
- Works for both Raycast commands: "Copy Latest Transcript" and "Fetch from Chrome Tabs"

## Changes
- Updated GraphQL queries to include `start_time` and `end_time` fields from the Fireflies API
- Modified `format_transcript()` method to display timestamps before each speaker line
- Added comprehensive test coverage for timestamp functionality
- Updated `.gitignore` to protect sensitive test data in `transcripts_for_testing/`

## Testing
- Tested with real Fireflies transcripts to verify timestamps are correctly formatted
- Added unit tests covering edge cases (mixed timestamps, long meetings, backward compatibility)
- All existing tests continue to pass

## Backward Compatibility
- Gracefully handles transcripts without timestamp data
- Falls back to original format when timestamps are unavailable
- No breaking changes to existing functionality

## Example Output
```
[00:00] Speaker A: Good.
[00:00] Speaker A: You good?
[00:02] Speaker A: Ready to talk a little about the project?
[00:05] Speaker B: Yeah.
[00:07] Speaker B: I'd love to see your workflow.
```

🤖 Generated with [Claude Code](https://claude.ai/code)