### PR TITLE
fix: Handle shared meeting URLs with query parameters

### DIFF
--- a/fetch_fireflies_from_chrome_tabs.py
+++ b/fetch_fireflies_from_chrome_tabs.py
@@ -80,7 +80,8 @@ def extract_transcript_ids(urls):
         transcript_ids = []
         # Updated pattern to handle both old format (with ::) and new format (without ::)
         # Transcript IDs must contain at least one digit to be valid
-        pattern = r"fireflies\.ai/view/(?:.*::)?([A-Za-z0-9]*[0-9]+[A-Za-z0-9]*)/?$"
+        # Also handles URLs with query parameters (?param=value)
+        pattern = r"fireflies\.ai/view/(?:.*::)?([A-Za-z0-9]*[0-9]+[A-Za-z0-9]*)(?:/|\?|$)"
 
         for url in urls:
             match = re.search(pattern, url)


### PR DESCRIPTION
## Summary
- Fixed regex pattern in transcript ID extraction to handle shared meeting URLs with query parameters
- Previously, shared meeting URLs containing query parameters (e.g., `?ref=...&track=...`) were not being recognized
- Updated pattern now accepts URLs ending with `?` in addition to `/` or end of string

## Problem
When users had Chrome tabs open with shared Fireflies meeting URLs (typically from email links), the script would fail to extract the transcript IDs because these URLs contain tracking parameters. The regex pattern was too restrictive, expecting URLs to end immediately after the transcript ID.

Example problematic URL:
```
https://app.fireflies.ai/view/Andrew-Arjun-Bhima::01K05BVDDTDRAF2SAAK8EK2D4P?ref=eJ1iYr589WZ&track=01K05BVDDTDRAF2SAAK8EK2D4P&sg=nb&utm_content=view_recap_cta&utm_campaign=meeting-recap-v2&utm_medium=email&utm_source=meeting_recap
```

## Solution
Updated the regex pattern from:
```python
pattern = r"fireflies\.ai/view/(?:.*::)?([A-Za-z0-9]*[0-9]+[A-Za-z0-9]*)/?$"
```

To:
```python
pattern = r"fireflies\.ai/view/(?:.*::)?([A-Za-z0-9]*[0-9]+[A-Za-z0-9]*)(?:/|\?|$)"
```

This change allows the pattern to match URLs that have query parameters after the transcript ID.

## Test plan
- [x] Tested with both owned and shared meeting URLs in Chrome tabs
- [x] Verified that transcript IDs are correctly extracted from URLs with and without query parameters
- [x] Confirmed that both transcripts are successfully fetched via the API
- [x] Script successfully copies both transcripts to clipboard

🤖 Generated with [Claude Code](https://claude.ai/code)