### PR TITLE
fix: Address Dependabot security vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ python-dotenv>=0.15.0
 python-dateutil>=2.8.0
 google-generativeai>=0.8.0
 
+# Security: explicit pins for transitive dependencies (Dependabot alerts)
+urllib3>=2.6.0
+filelock>=3.20.1
+
 # Testing dependencies
 pytest>=7.0.0
 pytest-cov>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ google-generativeai>=0.8.0
 
 # Security: explicit pins for transitive dependencies (Dependabot alerts)
 urllib3>=2.6.0
-filelock>=3.20.1
+filelock>=3.20.1; python_version >= "3.10"
 
 # Testing dependencies
 pytest>=7.0.0


### PR DESCRIPTION
## Summary
- Add explicit version pins for `urllib3>=2.6.0` to fix 2 High severity vulnerabilities (CVE-2025-66471, CVE-2025-66418)
- Add explicit version pin for `filelock>=3.20.1` to fix 1 Moderate severity vulnerability (CVE-2025-68146)
- These are transitive dependencies pulled in by `requests`, `google-generativeai`, and `pre-commit`

## Dependabot Alerts Addressed
| Alert | Severity | Package | Fixed Version |
|-------|----------|---------|---------------|
| #1 | High (8.9) | urllib3 | 2.6.0 |
| #2 | High (8.9) | urllib3 | 2.6.0 |
| #3 | Moderate (6.3) | filelock | 3.20.1 |

## Test plan
- [ ] Verify CI passes
- [ ] Confirm Dependabot alerts are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)